### PR TITLE
Add install subcommand for systemd registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,34 @@ The server runs on your local network. The ESP32 and your phone/laptop need to b
 
 **Accessing from outside your network:** Set up port forwarding on your router to forward an external port to `<server-ip>:8088`. The specifics depend on your router.
 
-## Running as a systemd Service
+## Installation
 
-A systemd unit file is provided in `contrib/therm-pro-server.service`. To install:
+Build and install as a systemd service:
+
+    make build
+    sudo ./bin/therm-pro-server install
+
+This will:
+- Copy the binary to `/usr/local/bin/therm-pro-server`
+- Create a `therm-pro` system user
+- Create `/var/lib/therm-pro` data directory
+- Install and enable a systemd unit
+
+To install to a different prefix (e.g. `/usr` or `/opt`):
+
+    sudo ./bin/therm-pro-server install --prefix=/usr
+
+Start the service:
+
+    sudo systemctl start therm-pro-server
+
+Preview without making changes:
+
+    ./bin/therm-pro-server install --dry-run
+
+## Running as a systemd Service (Manual)
+
+A systemd unit file is provided in `contrib/therm-pro-server.service`. To install manually:
 
 ```bash
 # Create a dedicated user

--- a/cmd/therm-pro-server/main.go
+++ b/cmd/therm-pro-server/main.go
@@ -129,6 +129,13 @@ func main() {
 }
 
 func runInstall() {
+	// Load config to pick up port from config.yaml / .env / env vars.
+	cfg, err := config.Load("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load config, using defaults: %v\n", err)
+		cfg = &config.Config{Port: 8088}
+	}
+
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s install [flags]\n\nInstall therm-pro-server as a systemd service.\n\nFlags:\n", os.Args[0])
@@ -136,7 +143,7 @@ func runInstall() {
 	}
 	dryRun := fs.Bool("dry-run", false, "print actions without executing")
 	prefix := fs.String("prefix", "/usr/local", "installation prefix (binary goes in <prefix>/bin/)")
-	port := fs.Int("port", 8088, "port for the service")
+	port := fs.Int("port", cfg.Port, "port for the service")
 	fs.Parse(os.Args[2:])
 
 	if os.Geteuid() != 0 && !*dryRun {

--- a/cmd/therm-pro-server/main.go
+++ b/cmd/therm-pro-server/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"log/slog"
@@ -128,20 +129,17 @@ func main() {
 }
 
 func runInstall() {
-	dryRun := false
-	prefix := "/usr/local"
-	for i, arg := range os.Args[2:] {
-		switch {
-		case arg == "--dry-run":
-			dryRun = true
-		case arg == "--prefix" && i+1 < len(os.Args[2:]):
-			prefix = os.Args[2+i+1]
-		case strings.HasPrefix(arg, "--prefix="):
-			prefix = strings.TrimPrefix(arg, "--prefix=")
-		}
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s install [flags]\n\nInstall therm-pro-server as a systemd service.\n\nFlags:\n", os.Args[0])
+		fs.PrintDefaults()
 	}
+	dryRun := fs.Bool("dry-run", false, "print actions without executing")
+	prefix := fs.String("prefix", "/usr/local", "installation prefix (binary goes in <prefix>/bin/)")
+	port := fs.Int("port", 8088, "port for the service")
+	fs.Parse(os.Args[2:])
 
-	if os.Geteuid() != 0 && !dryRun {
+	if os.Geteuid() != 0 && !*dryRun {
 		fmt.Fprintln(os.Stderr, "error: install must be run as root (try sudo)")
 		os.Exit(1)
 	}
@@ -153,11 +151,11 @@ func runInstall() {
 	}
 
 	opts := systemd.Options{
-		BinPath: systemd.DefaultBinPath(prefix),
+		BinPath: systemd.DefaultBinPath(*prefix),
 		User:    "therm-pro",
-		Port:    8088,
+		Port:    *port,
 		DataDir: "/var/lib/therm-pro",
-		DryRun:  dryRun,
+		DryRun:  *dryRun,
 	}
 
 	actions, err := systemd.Install(opts, self)
@@ -166,13 +164,13 @@ func runInstall() {
 		os.Exit(1)
 	}
 
-	if dryRun {
+	if *dryRun {
 		fmt.Println("Dry run — actions that would be taken:")
 	}
 	for _, a := range actions {
 		fmt.Printf("  %s\n", a)
 	}
-	if !dryRun {
+	if !*dryRun {
 		fmt.Println("\nInstalled. Start with: systemctl start therm-pro-server")
 	}
 }

--- a/cmd/therm-pro-server/main.go
+++ b/cmd/therm-pro-server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stahnma/therm-pro/internal/api"
 	"github.com/stahnma/therm-pro/internal/config"
 	"github.com/stahnma/therm-pro/internal/consul"
+	"github.com/stahnma/therm-pro/internal/systemd"
 )
 
 // GitCommit is set at build time via -ldflags.
@@ -83,6 +84,11 @@ func requestLogger(next http.Handler) http.Handler {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "install" {
+		runInstall()
+		return
+	}
+
 	cfg, err := config.Load("")
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
@@ -119,4 +125,54 @@ func main() {
 	slog.Info("shutting down")
 	consul.Deregister()
 	httpSrv.Shutdown(context.Background())
+}
+
+func runInstall() {
+	dryRun := false
+	prefix := "/usr/local"
+	for i, arg := range os.Args[2:] {
+		switch {
+		case arg == "--dry-run":
+			dryRun = true
+		case arg == "--prefix" && i+1 < len(os.Args[2:]):
+			prefix = os.Args[2+i+1]
+		case strings.HasPrefix(arg, "--prefix="):
+			prefix = strings.TrimPrefix(arg, "--prefix=")
+		}
+	}
+
+	if os.Geteuid() != 0 && !dryRun {
+		fmt.Fprintln(os.Stderr, "error: install must be run as root (try sudo)")
+		os.Exit(1)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: cannot determine binary path: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := systemd.Options{
+		BinPath: systemd.DefaultBinPath(prefix),
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  dryRun,
+	}
+
+	actions, err := systemd.Install(opts, self)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if dryRun {
+		fmt.Println("Dry run — actions that would be taken:")
+	}
+	for _, a := range actions {
+		fmt.Printf("  %s\n", a)
+	}
+	if !dryRun {
+		fmt.Println("\nInstalled. Start with: systemctl start therm-pro-server")
+	}
 }

--- a/cmd/therm-pro-server/main.go
+++ b/cmd/therm-pro-server/main.go
@@ -165,7 +165,7 @@ func runInstall() {
 		DryRun:  *dryRun,
 	}
 
-	actions, err := systemd.Install(opts, self)
+	actions, err := systemd.Install(opts, self, cfg.DataDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/docs/plans/2026-04-04-systemd-install.md
+++ b/docs/plans/2026-04-04-systemd-install.md
@@ -1,0 +1,514 @@
+# systemd Install Subcommand Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an `install` subcommand that copies the binary, creates a service user, and registers a systemd system unit.
+
+**Architecture:** Add an `internal/systemd` package that handles binary installation, user creation, unit file generation, and systemd registration. Route `os.Args[1] == "install"` in `main.go` before the existing server startup. The unit file is rendered from an embedded `text/template`. All operations require root and are idempotent. A `--dry-run` flag prints actions without executing.
+
+**Tech Stack:** Go stdlib (`os/exec`, `text/template`, `embed`), no new dependencies.
+
+---
+
+### Task 1: Create the systemd unit template
+
+**Files:**
+- Create: `internal/systemd/unit.tmpl`
+
+**Step 1: Write the template file**
+
+This is a `text/template` version of the existing `contrib/therm-pro-server.service`, parameterized:
+
+```ini
+[Unit]
+Description=Therm-Pro Temperature Monitoring Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{.User}}
+Group={{.User}}
+ExecStart={{.BinPath}}
+Restart=on-failure
+RestartSec=5
+
+Environment=PORT={{.Port}}
+
+StateDirectory=therm-pro
+WorkingDirectory={{.DataDir}}
+HOME={{.DataDir}}
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Step 2: Commit**
+
+```bash
+git add internal/systemd/unit.tmpl
+git commit -m "feat: add systemd unit file template"
+```
+
+---
+
+### Task 2: Implement the install package — unit rendering
+
+**Files:**
+- Create: `internal/systemd/install.go`
+- Test: `internal/systemd/install_test.go`
+
+**Step 1: Write the failing test for unit rendering**
+
+```go
+package systemd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderUnit(t *testing.T) {
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+	}
+	out, err := renderUnit(opts)
+	if err != nil {
+		t.Fatalf("renderUnit: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "ExecStart=/usr/local/bin/therm-pro-server") {
+		t.Errorf("missing ExecStart, got:\n%s", s)
+	}
+}
+
+func TestDefaultBinPath(t *testing.T) {
+	tests := []struct {
+		prefix string
+		want   string
+	}{
+		{"", "/usr/local/bin/therm-pro-server"},
+		{"/usr/local", "/usr/local/bin/therm-pro-server"},
+		{"/usr", "/usr/bin/therm-pro-server"},
+		{"/opt", "/opt/bin/therm-pro-server"},
+	}
+	for _, tt := range tests {
+		got := DefaultBinPath(tt.prefix)
+		if got != tt.want {
+			t.Errorf("DefaultBinPath(%q) = %q, want %q", tt.prefix, got, tt.want)
+		}
+	}
+}
+
+	if !strings.Contains(s, "User=therm-pro") {
+		t.Errorf("missing User, got:\n%s", s)
+	}
+	if !strings.Contains(s, "Environment=PORT=8088") {
+		t.Errorf("missing PORT, got:\n%s", s)
+	}
+	if !strings.Contains(s, "WorkingDirectory=/var/lib/therm-pro") {
+		t.Errorf("missing WorkingDirectory, got:\n%s", s)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: FAIL — `renderUnit` not defined.
+
+**Step 3: Write minimal implementation**
+
+`internal/systemd/install.go`:
+
+```go
+package systemd
+
+import (
+	"bytes"
+	"embed"
+	"text/template"
+)
+
+//go:embed unit.tmpl
+var unitFS embed.FS
+
+// Options configures the install.
+type Options struct {
+	BinPath string // full path to install the binary (derived from Prefix)
+	User    string // system user to create/run as (default therm-pro)
+	Port    int    // port for the Environment= line
+	DataDir string // working/state directory (default /var/lib/therm-pro)
+	DryRun  bool   // print plan without executing
+}
+
+// DefaultBinPath returns the install path for a given prefix (default /usr/local).
+// e.g. prefix="/usr" -> "/usr/bin/therm-pro-server"
+func DefaultBinPath(prefix string) string {
+	if prefix == "" {
+		prefix = "/usr/local"
+	}
+	return filepath.Join(prefix, "bin", "therm-pro-server")
+}
+
+func renderUnit(opts Options) (*bytes.Buffer, error) {
+	tmpl, err := template.ParseFS(unitFS, "unit.tmpl")
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, opts); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `make test`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/systemd/install.go internal/systemd/install_test.go
+git commit -m "feat: implement systemd unit rendering with template"
+```
+
+---
+
+### Task 3: Implement the install actions
+
+**Files:**
+- Modify: `internal/systemd/install.go`
+- Test: `internal/systemd/install_test.go`
+
+**Step 1: Write the failing test for dry-run**
+
+Dry-run mode exercises the full `Install()` path without touching the system. It returns the list of actions it *would* take.
+
+```go
+func TestInstallDryRun(t *testing.T) {
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  true,
+	}
+	actions, err := Install(opts, "/tmp/fake-binary")
+	if err != nil {
+		t.Fatalf("Install dry-run: %v", err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected actions, got none")
+	}
+	// Should describe copying binary, creating user, writing unit, reloading
+	joined := strings.Join(actions, "\n")
+	for _, want := range []string{"copy", "useradd", "mkdir", "write", "daemon-reload", "enable"} {
+		if !strings.Contains(strings.ToLower(joined), want) {
+			t.Errorf("missing action containing %q in:\n%s", want, joined)
+		}
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test`
+Expected: FAIL — `Install` not defined.
+
+**Step 3: Write the Install function**
+
+Add to `internal/systemd/install.go`:
+
+```go
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+)
+
+const (
+	unitPath    = "/etc/systemd/system/therm-pro-server.service"
+	serviceName = "therm-pro-server"
+)
+
+// Install performs the full systemd installation. srcBinary is the path to the
+// currently-running binary. Returns a list of action descriptions.
+func Install(opts Options, srcBinary string) ([]string, error) {
+	var actions []string
+	do := func(desc string, fn func() error) error {
+		actions = append(actions, desc)
+		if opts.DryRun {
+			return nil
+		}
+		return fn()
+	}
+
+	// 1. Copy binary
+	if err := do(fmt.Sprintf("copy %s -> %s", srcBinary, opts.BinPath), func() error {
+		return copyFile(srcBinary, opts.BinPath, 0755)
+	}); err != nil {
+		return actions, fmt.Errorf("copy binary: %w", err)
+	}
+
+	// 2. Create system user (idempotent)
+	if err := do(fmt.Sprintf("useradd --system --home-dir %s --shell /usr/sbin/nologin %s (skip if exists)", opts.DataDir, opts.User), func() error {
+		return createUser(opts.User, opts.DataDir)
+	}); err != nil {
+		return actions, fmt.Errorf("create user: %w", err)
+	}
+
+	// 3. Create data directory
+	if err := do(fmt.Sprintf("mkdir -p %s (owned by %s)", opts.DataDir, opts.User), func() error {
+		return createDataDir(opts.DataDir, opts.User)
+	}); err != nil {
+		return actions, fmt.Errorf("create data dir: %w", err)
+	}
+
+	// 4. Render and write unit file
+	unit, err := renderUnit(opts)
+	if err != nil {
+		return actions, fmt.Errorf("render unit: %w", err)
+	}
+	if err := do(fmt.Sprintf("write %s", unitPath), func() error {
+		return os.WriteFile(unitPath, unit.Bytes(), 0644)
+	}); err != nil {
+		return actions, fmt.Errorf("write unit: %w", err)
+	}
+
+	// 5. Reload and enable
+	if err := do("systemctl daemon-reload", func() error {
+		return exec.Command("systemctl", "daemon-reload").Run()
+	}); err != nil {
+		return actions, fmt.Errorf("daemon-reload: %w", err)
+	}
+	if err := do(fmt.Sprintf("systemctl enable %s", serviceName), func() error {
+		return exec.Command("systemctl", "enable", serviceName).Run()
+	}); err != nil {
+		return actions, fmt.Errorf("enable: %w", err)
+	}
+
+	return actions, nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func createUser(user, homeDir string) error {
+	// Check if user exists already
+	if err := exec.Command("id", user).Run(); err == nil {
+		return nil // already exists
+	}
+	return exec.Command("useradd", "--system", "--home-dir", homeDir, "--shell", "/usr/sbin/nologin", user).Run()
+}
+
+func createDataDir(dir, user string) error {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+	return exec.Command("chown", "-R", user+":"+user, dir).Run()
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `make test`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/systemd/install.go internal/systemd/install_test.go
+git commit -m "feat: implement Install() with dry-run support"
+```
+
+---
+
+### Task 4: Wire up the subcommand in main.go
+
+**Files:**
+- Modify: `cmd/therm-pro-server/main.go`
+
+**Step 1: Add install routing before the existing server startup**
+
+Insert at the top of `main()`, before `config.Load`:
+
+```go
+if len(os.Args) > 1 && os.Args[1] == "install" {
+    runInstall()
+    return
+}
+```
+
+Add the `runInstall` function:
+
+```go
+func runInstall() {
+	dryRun := false
+	prefix := "/usr/local"
+	for i, arg := range os.Args[2:] {
+		switch {
+		case arg == "--dry-run":
+			dryRun = true
+		case arg == "--prefix" && i+1 < len(os.Args[2:]):
+			prefix = os.Args[2+i+1]
+		case strings.HasPrefix(arg, "--prefix="):
+			prefix = strings.TrimPrefix(arg, "--prefix=")
+		}
+	}
+
+	if os.Geteuid() != 0 && !dryRun {
+		fmt.Fprintln(os.Stderr, "error: install must be run as root (try sudo)")
+		os.Exit(1)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: cannot determine binary path: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := systemd.Options{
+		BinPath: systemd.DefaultBinPath(prefix),
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  dryRun,
+	}
+
+	actions, err := systemd.Install(opts, self)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if dryRun {
+		fmt.Println("Dry run — actions that would be taken:")
+	}
+	for _, a := range actions {
+		fmt.Printf("  %s\n", a)
+	}
+	if !dryRun {
+		fmt.Println("\nInstalled. Start with: systemctl start therm-pro-server")
+	}
+}
+```
+
+Add the import for `"github.com/stahnma/therm-pro/internal/systemd"`.
+
+**Step 2: Build to verify it compiles**
+
+Run: `make build`
+Expected: compiles without errors.
+
+**Step 3: Verify dry-run works**
+
+Run: `./bin/therm-pro-server install --dry-run`
+Expected: prints the list of actions without requiring root, binary path defaults to `/usr/local/bin/therm-pro-server`.
+
+Run: `./bin/therm-pro-server install --dry-run --prefix=/opt`
+Expected: binary path shows `/opt/bin/therm-pro-server`.
+
+**Step 4: Commit**
+
+```bash
+git add cmd/therm-pro-server/main.go
+git commit -m "feat: wire up 'install' subcommand in main"
+```
+
+---
+
+### Task 5: Manual integration test
+
+This cannot be automated in CI (requires root + systemd). Verify on a real system:
+
+**Step 1: Build**
+
+Run: `make build`
+
+**Step 2: Run the install**
+
+Run: `sudo ./bin/therm-pro-server install`
+
+**Step 3: Verify**
+
+```bash
+id therm-pro                                    # user exists
+ls -la /usr/local/bin/therm-pro-server           # binary installed
+cat /etc/systemd/system/therm-pro-server.service # unit file correct
+systemctl is-enabled therm-pro-server            # "enabled"
+sudo systemctl start therm-pro-server
+systemctl status therm-pro-server                # active (running)
+curl http://localhost:8088/api/health             # responds
+sudo systemctl stop therm-pro-server
+```
+
+**Step 4: Final commit (if any fixups needed)**
+
+---
+
+### Task 6: Clean up and close
+
+**Step 1: Verify all tests pass**
+
+Run: `make test`
+Expected: PASS
+
+**Step 2: Final commit and note in README if desired**
+
+Add a usage note to README.md under an "Installation" section:
+
+```markdown
+## Installation
+
+Build and install as a systemd service:
+
+    make build
+    sudo ./bin/therm-pro-server install
+
+This will:
+- Copy the binary to `/usr/local/bin/therm-pro-server`
+- Create a `therm-pro` system user
+- Create `/var/lib/therm-pro` data directory
+- Install and enable a systemd unit
+
+To install to a different prefix (e.g. `/usr` or `/opt`):
+
+    sudo ./bin/therm-pro-server install --prefix=/usr
+
+Start the service:
+
+    sudo systemctl start therm-pro-server
+
+Preview without making changes:
+
+    ./bin/therm-pro-server install --dry-run
+```
+
+```bash
+git add README.md
+git commit -m "docs: add systemd installation instructions to README"
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,10 @@ func Load(dataDir string) (*Config, error) {
 		"log_level":       "info",
 	}, "."), nil)
 
-	// Resolve data dir
+	// Resolve data dir: explicit arg > THERM_PRO_DATA_DIR > ~/.therm-pro
+	if dataDir == "" {
+		dataDir = os.Getenv("THERM_PRO_DATA_DIR")
+	}
 	if dataDir == "" {
 		home, _ := os.UserHomeDir()
 		dataDir = filepath.Join(home, ".therm-pro")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,6 +124,29 @@ func TestEnvOverridesDotEnv(t *testing.T) {
 	}
 }
 
+func TestDataDirEnvOverride(t *testing.T) {
+	t.Setenv("THERM_PRO_DATA_DIR", "/var/lib/therm-pro")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DataDir != "/var/lib/therm-pro" {
+		t.Errorf("expected data_dir '/var/lib/therm-pro', got %s", cfg.DataDir)
+	}
+}
+
+func TestDataDirExplicitArgTakesPrecedence(t *testing.T) {
+	t.Setenv("THERM_PRO_DATA_DIR", "/should/be/ignored")
+	dir := t.TempDir()
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DataDir != dir {
+		t.Errorf("expected data_dir %q, got %s", dir, cfg.DataDir)
+	}
+}
+
 func TestLegacyPortEnv(t *testing.T) {
 	t.Setenv("PORT", "3000")
 	cfg, err := Load("")

--- a/internal/systemd/install.go
+++ b/internal/systemd/install.go
@@ -3,8 +3,17 @@ package systemd
 import (
 	"bytes"
 	"embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"text/template"
+)
+
+const (
+	unitPath    = "/etc/systemd/system/therm-pro-server.service"
+	serviceName = "therm-pro-server"
 )
 
 //go:embed unit.tmpl
@@ -38,4 +47,92 @@ func renderUnit(opts Options) (*bytes.Buffer, error) {
 		return nil, err
 	}
 	return &buf, nil
+}
+
+// Install performs the full systemd installation. srcBinary is the path to the
+// currently-running binary. Returns a list of action descriptions.
+func Install(opts Options, srcBinary string) ([]string, error) {
+	var actions []string
+	do := func(desc string, fn func() error) error {
+		actions = append(actions, desc)
+		if opts.DryRun {
+			return nil
+		}
+		return fn()
+	}
+
+	// 1. Copy binary
+	if err := do(fmt.Sprintf("copy %s -> %s", srcBinary, opts.BinPath), func() error {
+		return copyFile(srcBinary, opts.BinPath, 0755)
+	}); err != nil {
+		return actions, fmt.Errorf("copy binary: %w", err)
+	}
+
+	// 2. Create system user (idempotent)
+	if err := do(fmt.Sprintf("useradd --system --home-dir %s --shell /usr/sbin/nologin %s (skip if exists)", opts.DataDir, opts.User), func() error {
+		return createUser(opts.User, opts.DataDir)
+	}); err != nil {
+		return actions, fmt.Errorf("create user: %w", err)
+	}
+
+	// 3. Create data directory
+	if err := do(fmt.Sprintf("mkdir -p %s (owned by %s)", opts.DataDir, opts.User), func() error {
+		return createDataDir(opts.DataDir, opts.User)
+	}); err != nil {
+		return actions, fmt.Errorf("create data dir: %w", err)
+	}
+
+	// 4. Render and write unit file
+	unit, err := renderUnit(opts)
+	if err != nil {
+		return actions, fmt.Errorf("render unit: %w", err)
+	}
+	if err := do(fmt.Sprintf("write %s", unitPath), func() error {
+		return os.WriteFile(unitPath, unit.Bytes(), 0644)
+	}); err != nil {
+		return actions, fmt.Errorf("write unit: %w", err)
+	}
+
+	// 5. Reload and enable
+	if err := do("systemctl daemon-reload", func() error {
+		return exec.Command("systemctl", "daemon-reload").Run()
+	}); err != nil {
+		return actions, fmt.Errorf("daemon-reload: %w", err)
+	}
+	if err := do(fmt.Sprintf("systemctl enable %s", serviceName), func() error {
+		return exec.Command("systemctl", "enable", serviceName).Run()
+	}); err != nil {
+		return actions, fmt.Errorf("enable: %w", err)
+	}
+
+	return actions, nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func createUser(user, homeDir string) error {
+	if err := exec.Command("id", user).Run(); err == nil {
+		return nil
+	}
+	return exec.Command("useradd", "--system", "--home-dir", homeDir, "--shell", "/usr/sbin/nologin", user).Run()
+}
+
+func createDataDir(dir, user string) error {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+	return exec.Command("chown", "-R", user+":"+user, dir).Run()
 }

--- a/internal/systemd/install.go
+++ b/internal/systemd/install.go
@@ -1,0 +1,41 @@
+package systemd
+
+import (
+	"bytes"
+	"embed"
+	"path/filepath"
+	"text/template"
+)
+
+//go:embed unit.tmpl
+var unitFS embed.FS
+
+// Options configures the install.
+type Options struct {
+	BinPath string // full path to install the binary (derived from Prefix)
+	User    string // system user to create/run as (default therm-pro)
+	Port    int    // port for the Environment= line
+	DataDir string // working/state directory (default /var/lib/therm-pro)
+	DryRun  bool   // print plan without executing
+}
+
+// DefaultBinPath returns the install path for a given prefix (default /usr/local).
+// e.g. prefix="/usr" -> "/usr/bin/therm-pro-server"
+func DefaultBinPath(prefix string) string {
+	if prefix == "" {
+		prefix = "/usr/local"
+	}
+	return filepath.Join(prefix, "bin", "therm-pro-server")
+}
+
+func renderUnit(opts Options) (*bytes.Buffer, error) {
+	tmpl, err := template.ParseFS(unitFS, "unit.tmpl")
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, opts); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}

--- a/internal/systemd/install.go
+++ b/internal/systemd/install.go
@@ -109,6 +109,9 @@ func Install(opts Options, srcBinary string) ([]string, error) {
 }
 
 func copyFile(src, dst string, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -118,9 +121,11 @@ func copyFile(src, dst string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func createUser(user, homeDir string) error {
@@ -134,5 +139,5 @@ func createDataDir(dir, user string) error {
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return err
 	}
-	return exec.Command("chown", "-R", user+":"+user, dir).Run()
+	return exec.Command("chown", user+":"+user, dir).Run()
 }

--- a/internal/systemd/install.go
+++ b/internal/systemd/install.go
@@ -50,8 +50,10 @@ func renderUnit(opts Options) (*bytes.Buffer, error) {
 }
 
 // Install performs the full systemd installation. srcBinary is the path to the
-// currently-running binary. Returns a list of action descriptions.
-func Install(opts Options, srcBinary string) ([]string, error) {
+// currently-running binary. srcDataDir is the current data directory (e.g.
+// ~/.therm-pro) from which firmware and other data files are copied.
+// Returns a list of action descriptions.
+func Install(opts Options, srcBinary string, srcDataDir string) ([]string, error) {
 	var actions []string
 	do := func(desc string, fn func() error) error {
 		actions = append(actions, desc)
@@ -76,13 +78,35 @@ func Install(opts Options, srcBinary string) ([]string, error) {
 	}
 
 	// 3. Create data directory
-	if err := do(fmt.Sprintf("mkdir -p %s (owned by %s)", opts.DataDir, opts.User), func() error {
-		return createDataDir(opts.DataDir, opts.User)
+	if err := do(fmt.Sprintf("mkdir -p %s", opts.DataDir), func() error {
+		return createDataDir(opts.DataDir)
 	}); err != nil {
 		return actions, fmt.Errorf("create data dir: %w", err)
 	}
 
-	// 4. Render and write unit file
+	// 4. Copy firmware if present in source data dir
+	srcFirmwareDir := filepath.Join(srcDataDir, "firmware")
+	dstFirmwareDir := filepath.Join(opts.DataDir, "firmware")
+	for _, name := range []string{"firmware.bin", "version.json"} {
+		srcPath := filepath.Join(srcFirmwareDir, name)
+		if _, err := os.Stat(srcPath); err == nil {
+			dstPath := filepath.Join(dstFirmwareDir, name)
+			if err := do(fmt.Sprintf("copy %s -> %s", srcPath, dstPath), func() error {
+				return copyFile(srcPath, dstPath, 0644)
+			}); err != nil {
+				return actions, fmt.Errorf("copy firmware: %w", err)
+			}
+		}
+	}
+
+	// 5. Chown data dir (after firmware copy so new files are covered)
+	if err := do(fmt.Sprintf("chown %s %s", opts.User, opts.DataDir), func() error {
+		return chownTree(opts.DataDir, opts.User)
+	}); err != nil {
+		return actions, fmt.Errorf("chown data dir: %w", err)
+	}
+
+	// 6. Render and write unit file
 	unit, err := renderUnit(opts)
 	if err != nil {
 		return actions, fmt.Errorf("render unit: %w", err)
@@ -93,7 +117,7 @@ func Install(opts Options, srcBinary string) ([]string, error) {
 		return actions, fmt.Errorf("write unit: %w", err)
 	}
 
-	// 5. Reload and enable
+	// 7. Reload and enable
 	if err := do("systemctl daemon-reload", func() error {
 		return exec.Command("systemctl", "daemon-reload").Run()
 	}); err != nil {
@@ -135,9 +159,10 @@ func createUser(user, homeDir string) error {
 	return exec.Command("useradd", "--system", "--home-dir", homeDir, "--shell", "/usr/sbin/nologin", user).Run()
 }
 
-func createDataDir(dir, user string) error {
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return err
-	}
-	return exec.Command("chown", user+":"+user, dir).Run()
+func createDataDir(dir string) error {
+	return os.MkdirAll(dir, 0750)
+}
+
+func chownTree(dir, user string) error {
+	return exec.Command("chown", "-R", user+":"+user, dir).Run()
 }

--- a/internal/systemd/install_test.go
+++ b/internal/systemd/install_test.go
@@ -1,6 +1,8 @@
 package systemd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -42,7 +44,7 @@ func TestInstallDryRun(t *testing.T) {
 		DataDir: "/var/lib/therm-pro",
 		DryRun:  true,
 	}
-	actions, err := Install(opts, "/tmp/fake-binary")
+	actions, err := Install(opts, "/tmp/fake-binary", "/tmp/fake-datadir")
 	if err != nil {
 		t.Fatalf("Install dry-run: %v", err)
 	}
@@ -50,10 +52,57 @@ func TestInstallDryRun(t *testing.T) {
 		t.Fatal("expected actions, got none")
 	}
 	joined := strings.Join(actions, "\n")
-	for _, want := range []string{"copy", "useradd", "mkdir", "write", "daemon-reload", "enable"} {
+	for _, want := range []string{"copy", "useradd", "mkdir", "chown", "write", "daemon-reload", "enable"} {
 		if !strings.Contains(strings.ToLower(joined), want) {
 			t.Errorf("missing action containing %q in:\n%s", want, joined)
 		}
+	}
+}
+
+func TestInstallDryRunCopiesFirmware(t *testing.T) {
+	srcDir := t.TempDir()
+	fwDir := filepath.Join(srcDir, "firmware")
+	os.MkdirAll(fwDir, 0755)
+	os.WriteFile(filepath.Join(fwDir, "firmware.bin"), []byte("fake"), 0644)
+	os.WriteFile(filepath.Join(fwDir, "version.json"), []byte("{}"), 0644)
+
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  true,
+	}
+	actions, err := Install(opts, "/tmp/fake-binary", srcDir)
+	if err != nil {
+		t.Fatalf("Install dry-run: %v", err)
+	}
+	joined := strings.Join(actions, "\n")
+	if !strings.Contains(joined, "firmware.bin") {
+		t.Errorf("expected firmware.bin copy action, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "version.json") {
+		t.Errorf("expected version.json copy action, got:\n%s", joined)
+	}
+}
+
+func TestInstallDryRunSkipsMissingFirmware(t *testing.T) {
+	srcDir := t.TempDir() // no firmware subdir
+
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  true,
+	}
+	actions, err := Install(opts, "/tmp/fake-binary", srcDir)
+	if err != nil {
+		t.Fatalf("Install dry-run: %v", err)
+	}
+	joined := strings.Join(actions, "\n")
+	if strings.Contains(joined, "firmware") {
+		t.Errorf("expected no firmware actions, got:\n%s", joined)
 	}
 }
 

--- a/internal/systemd/install_test.go
+++ b/internal/systemd/install_test.go
@@ -1,0 +1,50 @@
+package systemd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderUnit(t *testing.T) {
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+	}
+	out, err := renderUnit(opts)
+	if err != nil {
+		t.Fatalf("renderUnit: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "ExecStart=/usr/local/bin/therm-pro-server") {
+		t.Errorf("missing ExecStart, got:\n%s", s)
+	}
+	if !strings.Contains(s, "User=therm-pro") {
+		t.Errorf("missing User, got:\n%s", s)
+	}
+	if !strings.Contains(s, "Environment=PORT=8088") {
+		t.Errorf("missing PORT, got:\n%s", s)
+	}
+	if !strings.Contains(s, "WorkingDirectory=/var/lib/therm-pro") {
+		t.Errorf("missing WorkingDirectory, got:\n%s", s)
+	}
+}
+
+func TestDefaultBinPath(t *testing.T) {
+	tests := []struct {
+		prefix string
+		want   string
+	}{
+		{"", "/usr/local/bin/therm-pro-server"},
+		{"/usr/local", "/usr/local/bin/therm-pro-server"},
+		{"/usr", "/usr/bin/therm-pro-server"},
+		{"/opt", "/opt/bin/therm-pro-server"},
+	}
+	for _, tt := range tests {
+		got := DefaultBinPath(tt.prefix)
+		if got != tt.want {
+			t.Errorf("DefaultBinPath(%q) = %q, want %q", tt.prefix, got, tt.want)
+		}
+	}
+}

--- a/internal/systemd/install_test.go
+++ b/internal/systemd/install_test.go
@@ -54,6 +54,26 @@ func TestInstallDryRun(t *testing.T) {
 	}
 }
 
+func TestRenderUnitCustomPort(t *testing.T) {
+	opts := Options{
+		BinPath: "/opt/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    9090,
+		DataDir: "/var/lib/therm-pro",
+	}
+	out, err := renderUnit(opts)
+	if err != nil {
+		t.Fatalf("renderUnit: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "Environment=PORT=9090") {
+		t.Errorf("expected PORT=9090, got:\n%s", s)
+	}
+	if !strings.Contains(s, "ExecStart=/opt/bin/therm-pro-server") {
+		t.Errorf("expected ExecStart=/opt/bin/therm-pro-server, got:\n%s", s)
+	}
+}
+
 func TestDefaultBinPath(t *testing.T) {
 	tests := []struct {
 		prefix string

--- a/internal/systemd/install_test.go
+++ b/internal/systemd/install_test.go
@@ -31,6 +31,29 @@ func TestRenderUnit(t *testing.T) {
 	}
 }
 
+func TestInstallDryRun(t *testing.T) {
+	opts := Options{
+		BinPath: "/usr/local/bin/therm-pro-server",
+		User:    "therm-pro",
+		Port:    8088,
+		DataDir: "/var/lib/therm-pro",
+		DryRun:  true,
+	}
+	actions, err := Install(opts, "/tmp/fake-binary")
+	if err != nil {
+		t.Fatalf("Install dry-run: %v", err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected actions, got none")
+	}
+	joined := strings.Join(actions, "\n")
+	for _, want := range []string{"copy", "useradd", "mkdir", "write", "daemon-reload", "enable"} {
+		if !strings.Contains(strings.ToLower(joined), want) {
+			t.Errorf("missing action containing %q in:\n%s", want, joined)
+		}
+	}
+}
+
 func TestDefaultBinPath(t *testing.T) {
 	tests := []struct {
 		prefix string

--- a/internal/systemd/install_test.go
+++ b/internal/systemd/install_test.go
@@ -29,6 +29,9 @@ func TestRenderUnit(t *testing.T) {
 	if !strings.Contains(s, "WorkingDirectory=/var/lib/therm-pro") {
 		t.Errorf("missing WorkingDirectory, got:\n%s", s)
 	}
+	if !strings.Contains(s, "Environment=THERM_PRO_DATA_DIR=/var/lib/therm-pro") {
+		t.Errorf("missing THERM_PRO_DATA_DIR, got:\n%s", s)
+	}
 }
 
 func TestInstallDryRun(t *testing.T) {

--- a/internal/systemd/unit.tmpl
+++ b/internal/systemd/unit.tmpl
@@ -12,6 +12,7 @@ Restart=on-failure
 RestartSec=5
 
 Environment=PORT={{.Port}}
+Environment=THERM_PRO_DATA_DIR={{.DataDir}}
 
 StateDirectory=therm-pro
 WorkingDirectory={{.DataDir}}

--- a/internal/systemd/unit.tmpl
+++ b/internal/systemd/unit.tmpl
@@ -1,0 +1,21 @@
+[Unit]
+Description=Therm-Pro Temperature Monitoring Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{.User}}
+Group={{.User}}
+ExecStart={{.BinPath}}
+Restart=on-failure
+RestartSec=5
+
+Environment=PORT={{.Port}}
+
+StateDirectory=therm-pro
+WorkingDirectory={{.DataDir}}
+HOME={{.DataDir}}
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/systemd/unit.tmpl
+++ b/internal/systemd/unit.tmpl
@@ -15,7 +15,6 @@ Environment=PORT={{.Port}}
 
 StateDirectory=therm-pro
 WorkingDirectory={{.DataDir}}
-HOME={{.DataDir}}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Closes #9

- Adds `therm-pro-server install` subcommand that copies the binary, creates a `therm-pro` system user, writes a systemd unit file, and enables the service
- Supports `--prefix` to install to `/usr/bin`, `/opt/bin`, etc. (default `/usr/local`)
- Supports `--port` to configure the service port (default 8088)
- Supports `--dry-run` to preview actions without root
- Supports `--help` for usage info

## Test plan

- [x] `make test` passes (unit tests for template rendering, DefaultBinPath, dry-run, custom port)
- [x] `./bin/therm-pro-server install --dry-run` prints expected actions
- [x] `./bin/therm-pro-server install --dry-run --prefix=/opt --port=9090` uses custom values
- [x] `./bin/therm-pro-server install --help` prints usage
- [x] `sudo ./bin/therm-pro-server install` on a real system (manual verification)