### PR TITLE
fix(esp32): detect TP25 BLE advertisement name

### DIFF
--- a/esp32/.gitignore
+++ b/esp32/.gitignore
@@ -1,0 +1,6 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+src/config.h

--- a/esp32/src/thermopro.cpp
+++ b/esp32/src/thermopro.cpp
@@ -34,16 +34,26 @@ void ThermoPro::notifyCallback(NimBLERemoteCharacteristic* pChar,
 bool ThermoPro::scan() {
     NimBLEScan* scan = NimBLEDevice::getScan();
     scan->setActiveScan(true);
+
+    Serial.println("Scanning BLE devices...");
     NimBLEScanResults results = scan->start(10);
 
     for (int i = 0; i < results.getCount(); i++) {
         NimBLEAdvertisedDevice adv = results.getDevice(i);
-        if (adv.getName() == "Thermopro") {
+        String name = adv.getName().c_str();
+
+        if (name == "TP25" || name == "Thermopro" || name == "ThermoPro") {
             device = new NimBLEAdvertisedDevice(adv);
-            Serial.println("Found ThermoPro TP25");
+            Serial.printf(
+                "Found ThermoPro TP25: name='%s' address=%s rssi=%d\n",
+                name.c_str(),
+                adv.getAddress().toString().c_str(),
+                adv.getRSSI()
+            );
             return true;
         }
     }
+
     Serial.println("ThermoPro not found");
     return false;
 }


### PR DESCRIPTION
## Summary

Adds support for TP25 devices that advertise over BLE using the name `TP25`.

Previously the ESP32 firmware only matched devices named `Thermopro`, which caused my TP25 unit to remain undetected during BLE scanning.

## Tested

- Flashed ESP32 using PlatformIO.
- Confirmed WiFi connection to Therm-Pro server.
- Confirmed BLE scan sees the device as `TP25`.
- Confirmed ESP32 connects and streams probe data to `/api/data`.
- Confirmed dashboard displays live probe temperatures.

## Notes

Observed BLE advertisement:

- name: `TP25`
- device type: ThermoPro TP25